### PR TITLE
Logging with `log` and `env_logger` crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2021"
 "miette" = {version = ">=5.5", features = ["fancy"]}
 "thiserror" = "1.0"
 "clap" = {version = "4.1.8", features=["cargo"]}
+env_logger = "0.10.0"
+log = "0.4.17"
+chrono = "0.4.24"

--- a/hdllang/Cargo.toml
+++ b/hdllang/Cargo.toml
@@ -3,7 +3,7 @@ name = "hdllang"
 version = "0.1.0"
 edition = "2021"
 
-[build-dependencies] # <-- We added this and everything after!
+[build-dependencies]
 lalrpop = "0.19.9"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -15,3 +15,4 @@ lalrpop = "0.19.9"
 "bimap" = "0.6.2"
 lalrpop-util = {version = "0.19.7",  features = ["lexer"]}
 "regex" = "1"
+log = "0.4.17"


### PR DESCRIPTION
`RUST_LOG` and `RUST_LOG_FILE` env vars can be used to control logging. Closes #33.