### PR TITLE
Implement `Serialize` and `Deserialize` for `IdTable`, `NumericConstantTable` and `CommentTable`

### DIFF
--- a/hdllang/Cargo.toml
+++ b/hdllang/Cargo.toml
@@ -12,8 +12,8 @@ lalrpop = "0.20.0"
 "miette" = ">=5.5"
 "logos" = "0.13.0"
 "thiserror" = "1.0"
-"bimap" = "0.6.2"
-"num-bigint" = "0.4.3"
+"bimap" = {version = "0.6.2", features = ["serde"]}
+"num-bigint" = {version = "0.4.3", features = ["serde"]}
 "derive_more" = "0.99.17"
 lalrpop-util = {version = "0.20.0",  features = ["lexer"]}
 "regex" = "1"

--- a/hdllang/src/core/comment_table.rs
+++ b/hdllang/src/core/comment_table.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 /// Used to access metadata comments
-/// use serde::{Serialize, Deserialize};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, Hash, PartialEq, Eq)]
@@ -10,7 +9,7 @@ pub struct CommentTableKey {
 }
 
 /// Stores metadata comments
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CommentTable {
 	comments: HashMap<CommentTableKey, String>,
 }

--- a/hdllang/src/core/id_table.rs
+++ b/hdllang/src/core/id_table.rs
@@ -1,15 +1,14 @@
 use bimap::BiHashMap;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
 /// Opaque key type for the lexer ID table
-#[derive(Hash, PartialEq, Eq, Clone, Copy, Debug)]
+#[derive(Hash, PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct IdTableKey {
 	key: usize,
 }
 
 /// Lexer's ID table - used to avoid storing tokens in strings
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IdTable {
 	ids: BiHashMap<IdTableKey, String>,
 }

--- a/hdllang/src/core/numeric_constant_table.rs
+++ b/hdllang/src/core/numeric_constant_table.rs
@@ -8,6 +8,7 @@ pub struct NumericConstantTableKey {
 	key: usize,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NumericConstantTable {
 	constants: HashMap<NumericConstantTableKey, NumericConstant>,
 }

--- a/hdllang/src/core/source_span.rs
+++ b/hdllang/src/core/source_span.rs
@@ -1,9 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::ops::Range;
 
-#[derive(Serialize, Deserialize)]
 /// Indicates a region in the source code
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct SourceSpan {
 	start: usize,
 	end: usize,

--- a/hdllang/src/core/wide_int.rs
+++ b/hdllang/src/core/wide_int.rs
@@ -1,17 +1,18 @@
 use derive_more::{Add, Display};
 use num_bigint::BigInt;
 use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
 
 /// Dynamic-wdith signed integer
 /// Backbone of all integer operations in the compiler
-#[derive(Clone, Add, Display)]
+#[derive(Clone, Add, Display, Serialize, Deserialize)]
 pub struct WideInt {
 	value: BigInt,
 }
 
 /// Dynamic-wdith unsigned integer
 /// Backbone of all integer operations in the compiler
-#[derive(Clone, Display, Debug, PartialEq, Eq)]
+#[derive(Clone, Display, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WideUint {
 	value: BigUint,
 }

--- a/hdllang/src/lexer/numeric_constant.rs
+++ b/hdllang/src/lexer/numeric_constant.rs
@@ -1,6 +1,8 @@
 use crate::core::WideUint;
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug)]
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NumericConstant {
 	pub value: WideUint,
 	pub width: Option<u32>,


### PR DESCRIPTION
Resolves #64. The next step is to implement some sort of serialization context, but that's front-end related, so leaving that up to you.