### PR TITLE
Fix bug in the grammar in use statements and package declarations

### DIFF
--- a/hdllang/src/parser/grammar.lalrpop
+++ b/hdllang/src/parser/grammar.lalrpop
@@ -38,7 +38,7 @@ pub TopDefinition: TopDefinition={
 			statement,
 			location:SourceSpan::new_between(start,end),
 		})},
-	<start: @L> <mc:MetadataComments ?> "package" <path:ImportPath> ";"  <end: @R> =>
+	<start: @L> <mc:MetadataComments ?> "package" <path:SingleImportPath> ";"  <end: @R> =>
 		{
 			let metadata = match mc{
 				Some(mc) => mc,
@@ -50,7 +50,7 @@ pub TopDefinition: TopDefinition={
 				location:SourceSpan::new_between(start,end),
 			})
 		},
-		<start: @L> <mc:MetadataComments ?> "use" <path:SingleImportPath> ";"  <end: @R> =>
+		<start: @L> <mc:MetadataComments ?> "use" <path:ImportPath> ";"  <end: @R> =>
 		{
 			let metadata = match mc{
 				Some(mc) => mc,

--- a/hdllang/tests/parser_test.rs
+++ b/hdllang/tests/parser_test.rs
@@ -119,6 +119,18 @@ mod top_definition_parser_test {
 	}
 
 	#[test]
+	fn use_multiple_modules(){
+		let s = "use foo::bar::{baz, qux};";
+		parse_top_definition_pass(s);
+	}
+
+	#[test]
+	fn package_multiple() {
+		let s = "package foo::bar::{baz, boo};";
+		parse_top_definition_fail(s);
+	}
+
+	#[test]
 	fn use_missing_semicolon() {
 		let s = "use foo::bar::baz";
 		parse_top_definition_fail(s);


### PR DESCRIPTION
Now, proper import paths are allowed. Fixed code was covered in the tests.