### PR TITLE
Drop `Design` type and rely solely on `DesignHandle` now

### DIFF
--- a/hdllang/src/analyzer/combining_pass.rs
+++ b/hdllang/src/analyzer/combining_pass.rs
@@ -31,7 +31,7 @@ pub fn combine<'a>(
 	if path_from_root.as_str() == "" {
 		path_from_root = ".".to_string();
 	}
-	let mut design = hirn::design::Design::new();
+	let mut design = hirn::design::DesignHandle::new();
 	let mut packaged_paths: Vec<String> = Vec::new();
 	let mut modules_declared: HashMap<IdTableKey, ModuleDeclared> = HashMap::new();
 	let mut modules_implemented: HashMap<IdTableKey, &ModuleImplementation> = HashMap::new();
@@ -168,7 +168,7 @@ impl<'a> SemanticalAnalyzer<'a> {
 				pass(&mut self.ctx, &mut local_ctx, *module)?;
 			}
 			let mut output_string = String::new();
-			let mut sv_codegen = hirn::codegen::sv::SVCodegen::new(&mut self.ctx.design, &mut output_string);
+			let mut sv_codegen = hirn::codegen::sv::SVCodegen::new(self.ctx.design.clone(), &mut output_string);
 			use hirn::codegen::Codegen;
 			sv_codegen
 				.emit_module(
@@ -227,7 +227,7 @@ pub struct GlobalAnalyzerContext<'a> {
 	pub modules_declared: HashMap<IdTableKey, ModuleDeclared>,
 	/// represents all implemented generic modules
 	pub generic_modules: HashMap<IdTableKey, &'a ModuleImplementation>,
-	pub design: hirn::design::Design,
+	pub design: hirn::design::DesignHandle,
 }
 /// Per module context for semantic analysis
 pub struct LocalAnalyzerContex {

--- a/hdllang/src/analyzer/signal_sensitivity.rs
+++ b/hdllang/src/analyzer/signal_sensitivity.rs
@@ -238,7 +238,7 @@ mod tests {
 			nc_table,
 			modules_declared: HashMap::new(),
 			generic_modules: HashMap::new(),
-			design: hirn::design::Design::new(),
+			design: hirn::design::DesignHandle::new(),
 		}
 	}
 	fn span() -> SourceSpan {

--- a/hdllang/src/parser/ast/top_definition.rs
+++ b/hdllang/src/parser/ast/top_definition.rs
@@ -1,6 +1,6 @@
 mod pretty_printable;
 
-use hirn::design::Design;
+use hirn::design::DesignHandle;
 use log::info;
 
 use crate::analyzer::{AlreadyCreated, ModuleDeclared, ModuleImplementationScope, SemanticError, Variable};
@@ -194,7 +194,7 @@ pub struct ModuleDeclaration {
 impl ModuleDeclaration {
 	pub fn analyze(
 		&self,
-		design_handle: &mut Design,
+		design_handle: &mut DesignHandle,
 		id_table: &IdTable,
 		nc_table: &crate::lexer::NumericConstantTable,
 		modules_declared: &mut HashMap<IdTableKey, ModuleDeclared>,

--- a/hirn/src/design/expression/eval.rs
+++ b/hirn/src/design/expression/eval.rs
@@ -23,7 +23,6 @@ impl EvalContext {
 
 	fn check_assumption(&self, signal: SignalId, indices: &Vec<i64>, value: &NumericConstant) -> Result<(), EvalError> {
 		if let Some(design) = &self.design {
-			let design = design.borrow();
 			let sig = design.get_signal(signal).unwrap();
 
 			// We cannot fully check for errors here - e.g. in case where

--- a/hirn/src/design/expression/expression_eval.rs
+++ b/hirn/src/design/expression/expression_eval.rs
@@ -15,7 +15,6 @@ impl Evaluates for NumericConstant {
 impl Evaluates for SignalId {
 	fn eval(&self, ctx: &EvalContext) -> Result<NumericConstant, EvalError> {
 		if let Some(design) = ctx.design() {
-			let design = design.borrow();
 			let signal = design.get_signal(*self).unwrap();
 
 			if !signal.is_scalar() {

--- a/hirn/src/design/expression/expression_validate.rs
+++ b/hirn/src/design/expression/expression_validate.rs
@@ -320,8 +320,7 @@ impl ConditionalExpression {
 
 fn shallow_validate_slice(slice: &SignalSlice, ctx: &EvalContext, scope: &ScopeHandle) -> Result<(), EvalError> {
 	let design_handle = scope.design();
-	let design = design_handle.borrow();
-	let signal = design.get_signal(slice.signal).expect("Signal not in design");
+	let signal = design_handle.get_signal(slice.signal).expect("Signal not in design");
 
 	// Validate rank
 	if signal.rank() != slice.indices.len() {
@@ -392,11 +391,11 @@ impl Expression {
 #[cfg(test)]
 mod test {
 	use super::*;
-	use crate::design::{Design, DesignError};
+	use crate::design::{DesignHandle, DesignError};
 
 	#[test]
 	fn basic_scope_rule_test() -> Result<(), DesignError> {
-		let mut d = Design::new();
+		let mut d = DesignHandle::new();
 		let m1 = d.new_module("m1")?;
 		let m2 = d.new_module("m2")?;
 
@@ -412,7 +411,7 @@ mod test {
 
 	#[test]
 	fn shadowing_test() -> Result<(), DesignError> {
-		let mut d = Design::new();
+		let mut d = DesignHandle::new();
 		let m1 = d.new_module("m1")?;
 
 		let sig_outer_foo = m1.scope().new_signal("foo")?.generic().unsigned(16u32.into()).build()?;
@@ -447,7 +446,7 @@ mod test {
 
 	#[test]
 	fn static_bad_index_check() -> Result<(), DesignError> {
-		let mut d = Design::new();
+		let mut d = DesignHandle::new();
 		let m1 = d.new_module("m1")?;
 
 		let sig_foo = m1

--- a/hirn/src/design/expression/narrow_eval.rs
+++ b/hirn/src/design/expression/narrow_eval.rs
@@ -35,8 +35,7 @@ impl NarrowEval for BuiltinOp {
 				match **expr {
 					Signal(ref slice) => {
 						if let Some(design_handle) = ctx.design() {
-							let design = design_handle.borrow();
-							let sig = design.get_signal(slice.signal).expect("signal not in design");
+							let sig = design_handle.get_signal(slice.signal).expect("signal not in design");
 							return Ok(sig.width().narrow_eval(ctx)?);
 						}
 

--- a/hirn/src/design/expression/type_eval.rs
+++ b/hirn/src/design/expression/type_eval.rs
@@ -16,7 +16,6 @@ impl EvaluatesType for NumericConstant {
 impl EvaluatesType for SignalId {
 	fn eval_type(&self, ctx: &EvalContext) -> Result<EvalType, EvalError> {
 		if let Some(design) = ctx.design() {
-			let design = design.borrow();
 			let signal = design.get_signal(*self).expect("Evaluated signal must be in design");
 			Ok(EvalType {
 				signedness: signal.signedness(),

--- a/hirn/src/design/module.rs
+++ b/hirn/src/design/module.rs
@@ -1,5 +1,5 @@
 use super::{
-	Design, DesignCore, DesignError, DesignHandle, HasComment, HasSensitivity, ModuleId, ScopeHandle, ScopeId, SignalId,
+	DesignCore, DesignError, DesignHandle, HasComment, HasSensitivity, ModuleId, ScopeHandle, ScopeId, SignalId,
 };
 
 /// Specifies direction for signals in module interface

--- a/hirn/src/example/main.rs
+++ b/hirn/src/example/main.rs
@@ -1,12 +1,12 @@
 extern crate hirn;
 use hirn::{
 	codegen::{sv::SVCodegen, Codegen},
-	design::{Design, Expression, SignalDirection},
+	design::{DesignHandle, Expression, SignalDirection},
 	HirnError,
 };
 
 fn main() -> Result<(), HirnError> {
-	let mut d = Design::new();
+	let mut d = DesignHandle::new();
 
 	let mut m_internal = d.new_module("inner_module").unwrap();
 	let internal_clk = m_internal.scope().new_signal("clk")?.clock().wire().build()?;
@@ -68,7 +68,7 @@ fn main() -> Result<(), HirnError> {
 	loop_scope.assign(m_bus.into(), iter.into())?;
 
 	let mut source = String::new();
-	let mut cg = SVCodegen::new(&d, &mut source);
+	let mut cg = SVCodegen::new(d.clone(), &mut source);
 	cg.emit_module(m_internal.id())?;
 	cg.emit_module(m.id())?;
 


### PR DESCRIPTION
So, `DesignHandle` is now the type representing the design during build phase. Later on, we can have `DesignHandle::take_core() -> DesignCore` which would return actually immutable design representation which could be shared among threads during elab/codegen.