### PR TITLE
SV Codegen: `localparam`s with specified width

### DIFF
--- a/tests/input/004_localparams.hirl
+++ b/tests/input/004_localparams.hirl
@@ -1,6 +1,7 @@
 module m {}
 impl m {
 	int n;
+	int k = 1u1;
 	{
 		{
 			{
@@ -8,5 +9,6 @@ impl m {
 			}
 		}
 	}
+	int m = k + n;
 	const unsigned bus<n> b;
 }


### PR DESCRIPTION
Later on, we'll see what happens when all expressions are translated in a width-aware manner. That shouldn't matter now unless HIRL suddenly adds support for non-64-bit generic types.