### PR TITLE
Codegen width-aware expressions in join/rep builtin ops

### DIFF
--- a/hirn/src/codegen/sv/sv_expr.rs
+++ b/hirn/src/codegen/sv/sv_expr.rs
@@ -382,7 +382,9 @@ impl SVExpressionCodegen {
 			},
 
 			Replicate { expr, count } => {
+				self.push_width_casts(true);
 				let expr_str = self.translate_expression_no_preprocess(expr)?;
+				self.pop_width_casts();
 				self.push_width_casts(false);
 				let count_str = self.translate_expression_try_eval(count)?;
 				self.pop_width_casts();
@@ -390,6 +392,7 @@ impl SVExpressionCodegen {
 			},
 
 			Join(exprs) => {
+				self.push_width_casts(true);
 				let mut str = "{ ".into();
 				for (index, expr) in exprs.iter().enumerate() {
 					str = format!(
@@ -399,6 +402,7 @@ impl SVExpressionCodegen {
 						if index == exprs.len() - 1 { "" } else { ", " }
 					);
 				}
+				self.pop_width_casts();
 				format!("{} }}", str)
 			},
 		})


### PR DESCRIPTION
That should do it. I cannot reproduce on main, needs testing by @WojciechPtas on some other branch.